### PR TITLE
add new function to sequence_list_generator.py and modify sequence_generator.py

### DIFF
--- a/src/sequence_generator.py
+++ b/src/sequence_generator.py
@@ -85,6 +85,8 @@ class Cond(Program):
 class Loop(Program):
     @staticmethod
     def loop_impl(f: Callable[[int, int], int], a: int, b: int) -> int:
+        if a < 0:
+            raise Exception("Invalid loop parameter: 'a' must be greater than or equal to 0.")
         while a > 0:
             b = f(b, a)
             a -= 1
@@ -106,6 +108,8 @@ class Loop2(Program):
     def loop2_impl(f: Callable[[int, int], int],
                    g: Callable[[int, int], int],
                    a: int, b: int, c: int) -> int:
+        if a < 0:
+            raise Exception("Invalid loop2 parameter: 'a' must be greater than or equal to 0.")
         while a > 0:
             b, c = f(b, c), g(b,c)
             a -= 1
@@ -126,19 +130,21 @@ class Loop2(Program):
 
 class Compr(Program):
     @staticmethod
-    def compr_impl(f:Callable[[int, int], int], a:int):
+    def compr_impl(f:Callable[[int, int], int], a:int, max_iter:int) -> int:
         if a == 0:
             m = 0
-            while True:
+            while m < max_iter:
                 if f(m, 0) <= 0:
                     return m
                 m += 1
+            raise Exception('compr_impl reached max_iter')
         elif a > 0:
             m = 0
-            while True:
-                if m > Compr.compr_impl(f, a-1) and f(m, 0) <= 0:
+            while m < max_iter:
+                if m > Compr.compr_impl(f, a-1, max_iter) and f(m, 0) <= 0:
                     return m
                 m += 1
+            raise Exception('compr_impl reached max_iter')
         else:
             raise Exception('compr error')
 
@@ -148,8 +154,10 @@ class Compr(Program):
         
         ff = self.sub_programs['f'].build()
         fa = self.sub_programs['a'].build()
-        
-        self.fn = lambda x, y: self.compr_impl(ff, fa(x,y))
+
+        max_iter = 10
+
+        self.fn = lambda x, y: self.compr_impl(ff, fa(x,y), max_iter)
         return self.fn
     
 class Plus(Program):
@@ -193,6 +201,8 @@ class Division(Program):
         fa = self.sub_programs['a'].build()
         fb = self.sub_programs['b'].build()
         
+        if lambda x, y: fb(x,y)==0:
+            raise Exception("Division by zero")
         self.fn = lambda x, y: fa(x,y) // fb(x,y)
         return self.fn
 
@@ -204,6 +214,8 @@ class Mod(Program):
         fa = self.sub_programs['a'].build()
         fb = self.sub_programs['b'].build()
         
+        if lambda x, y: fb(x,y)==0:
+            raise Exception("Mod by zero")
         self.fn = lambda x, y: fa(x,y) % fb(x,y)
         return self.fn
 

--- a/src/sequence_generator.py
+++ b/src/sequence_generator.py
@@ -211,7 +211,7 @@ class ProgramStack:
     STR2RPN_LIST = ['0', '1', '2', 'plus', 'minus', 'multiply', 'div', 'mod', 'cond', 'loop', 'x', 'y', 'compr', 'loop2']
 
     def __init__(self, rpn):
-        self.rpn = rpn
+        self.rpn = self.str2rpn(rpn)
         self.stack = []
     
     @staticmethod
@@ -257,7 +257,7 @@ class ProgramStack:
                 b = self.stack.pop()
                 a = self.stack.pop()
                 self.stack.append(Multiply(a=a, b=b))
-            elif s == 'division':
+            elif s == 'div':
                 b = self.stack.pop()
                 a = self.stack.pop()
                 self.stack.append(Division(a=a, b=b))

--- a/src/sequence_list_generator.py
+++ b/src/sequence_list_generator.py
@@ -1,0 +1,106 @@
+#A=0 B=1 C=2 D=+ E=- F=* G=div H=mod I=cond J=loop K=x L=y M=compr N=loop2
+import random
+import math
+import calc
+
+# program_num に応じた生成できるトークンたちを dict型で variation_of_letterに保存、variation_of_letter_reducing_program_num は program_num を減らす場合のもの
+lettersvariation = {'A':1, 'B':1, 'C':1, 'D':-1, 'E':-1, 'F':-1, 'G':-1, 'H':-1, 'I':-2, 'J':-2, 'K':1, 'L':1, 'M':-1, 'N':-4}
+variation_of_letter={}
+variation_of_letter_reducing_program_num={}
+for i in range(100):
+    letters=[]
+    for k, v in lettersvariation.items():    
+        if 1-i <= v <= 1:
+            letters.append(k)
+    variation_of_letter[i]=letters
+for i in range(2, 100):
+    letters=[]
+    for k, v in lettersvariation.items():    
+        if 1-i <= v <= -1:
+            letters.append(k)
+    variation_of_letter_reducing_program_num[i]=letters
+class ProgramGenerator(): 
+    # トークンに応じた program_num の変化量を dict で定義
+    VARIATION_OF_PROGRAM_NUM={'A':1, 'B':1, 'C':1, 'D':-1, 'E':-1, 'F':-1, 'G':-1, 'H':-1, 'I':-2, 'J':-2, 'K':1, 'L':1, 'M':-1, 'N':-4}
+    # 上記のプログラムの dict をクラス変数に
+    VARIATION_OF_LETTER=variation_of_letter
+    VARIATION_OF_LETTER_REDUCING_PROGRAM_NUM=variation_of_letter_reducing_program_num
+    
+    def __init__(self):
+        self.program_num=0 #リストをProgramStack()でオブジェクト化した時の要素数
+        self.sequence=[]
+        self.information_amount=0 #複雑度
+        self.max_variation_of_program_num=1
+    
+    def append_letter(self):
+        letter, information_amount= self.generate_random_letter(self.program_num, self.max_variation_of_program_num)
+        self.sequence.append(letter)
+        self.update_program_num(letter)
+        self.add_information_amount(information_amount)
+
+    def generate_random_letter(self, min_variation, max_variation):
+        if max_variation==1:
+            return random.choice(self.VARIATION_OF_LETTER[min_variation]), math.log(len(self.VARIATION_OF_LETTER[min_variation]), 2)
+        else:
+            return random.choice(self.VARIATION_OF_LETTER_REDUCING_PROGRAM_NUM[min_variation]), math.log(len(self.VARIATION_OF_LETTER_REDUCING_PROGRAM_NUM[min_variation]), 2)
+    
+    def change_max_variation_of_program_num(self):
+        self.max_variation_of_program_num=-1
+        self.letter_of_choice={}
+
+    def add_information_amount(self, information_amount):
+        self.information_amount+=information_amount 
+
+    def update_program_num(self, r): #rの値に応じてprogram_numを増減
+        self.program_num+=self.VARIATION_OF_PROGRAM_NUM[r]   
+    
+    def generate_token(self):
+        self.append_letter()
+
+    def program_num_info(self): # program_num を出力
+        return self.program_num
+    
+    def sequence_info(self): # sequence を出力
+        return self.sequence
+    
+    def information_amount_info(self): # information_amount を出力
+        return self.information_amount
+
+def generate():
+    sequence=ProgramGenerator()
+    n=0
+    a=1
+    while(a>n):
+        sequence.generate_token()
+        n+=1
+        a=random.randint(0, 100)
+        
+    sequence.change_max_variation_of_program_num()
+    while(sequence.program_num_info()>1):
+        sequence.generate_token()
+    
+    return sequence.sequence_info(), sequence.information_amount_info()
+
+def sorting():
+    while(True):
+        try:
+            sequence=[]
+            information_amount=0
+            sequence, information_amount=generate()
+            ps=calc.ProgramStack(sequence)
+            stack=ps.build()
+            if 'y' not in stack[0].find_free_variables():
+                if not stack[0].calc(1, 0)==stack[0].calc(10, 0):
+                    for num in range(1, 11):
+                        print(stack[0].calc(num, 0))
+                    break
+        except Exception:
+            continue
+
+    return sequence, information_amount
+
+for num in range(100):
+    g, h=sorting()
+    print(calc.ProgramStack.str2rpn(g))
+
+#A=0 B=1 C=2 D=+ E=- F=* G=div H=mod I=cond J=loop K=x L=y M=compr N=loop2

--- a/src/sequence_list_generator.py
+++ b/src/sequence_list_generator.py
@@ -1,61 +1,38 @@
 #A=0 B=1 C=2 D=+ E=- F=* G=div H=mod I=cond J=loop K=x L=y M=compr N=loop2
 import random
 import math
-import calc
+import sequence_generator
 
-# program_num に応じた生成できるトークンたちを dict型で variation_of_letterに保存、variation_of_letter_reducing_program_num は program_num を減らす場合のもの
-lettersvariation = {'A':1, 'B':1, 'C':1, 'D':-1, 'E':-1, 'F':-1, 'G':-1, 'H':-1, 'I':-2, 'J':-2, 'K':1, 'L':1, 'M':-1, 'N':-4}
-variation_of_letter={}
-variation_of_letter_reducing_program_num={}
-for i in range(100):
-    letters=[]
-    for k, v in lettersvariation.items():    
-        if 1-i <= v <= 1:
-            letters.append(k)
-    variation_of_letter[i]=letters
-for i in range(2, 100):
-    letters=[]
-    for k, v in lettersvariation.items():    
-        if 1-i <= v <= -1:
-            letters.append(k)
-    variation_of_letter_reducing_program_num[i]=letters
+
 class ProgramGenerator(): 
     # トークンに応じた program_num の変化量を dict で定義
     VARIATION_OF_PROGRAM_NUM={'A':1, 'B':1, 'C':1, 'D':-1, 'E':-1, 'F':-1, 'G':-1, 'H':-1, 'I':-2, 'J':-2, 'K':1, 'L':1, 'M':-1, 'N':-4}
-    # 上記のプログラムの dict をクラス変数に
-    VARIATION_OF_LETTER=variation_of_letter
-    VARIATION_OF_LETTER_REDUCING_PROGRAM_NUM=variation_of_letter_reducing_program_num
     
     def __init__(self):
         self.program_num=0 #リストをProgramStack()でオブジェクト化した時の要素数
         self.sequence=[]
         self.information_amount=0 #複雑度
-        self.max_variation_of_program_num=1
     
-    def append_letter(self):
-        letter, information_amount= self.generate_random_letter(self.program_num, self.max_variation_of_program_num)
+    def append_letter(self, max_variation=1):
+        letter, information_amount= self.generate_random_letter(1-self.program_num, max_variation)
         self.sequence.append(letter)
         self.update_program_num(letter)
         self.add_information_amount(information_amount)
 
     def generate_random_letter(self, min_variation, max_variation):
-        if max_variation==1:
-            return random.choice(self.VARIATION_OF_LETTER[min_variation]), math.log(len(self.VARIATION_OF_LETTER[min_variation]), 2)
-        else:
-            return random.choice(self.VARIATION_OF_LETTER_REDUCING_PROGRAM_NUM[min_variation]), math.log(len(self.VARIATION_OF_LETTER_REDUCING_PROGRAM_NUM[min_variation]), 2)
-    
-    def change_max_variation_of_program_num(self):
-        self.max_variation_of_program_num=-1
-        self.letter_of_choice={}
+        letter2variation = {'A':1, 'B':1, 'C':1, 'D':-1, 'E':-1, 'F':-1, 'G':-1, 'H':-1, 'I':-2, 'J':-2, 'K':1, 'L':1, 'M':-1, 'N':-4}
+        letters=[]
+        for k, v in letter2variation.items():    
+            if min_variation <= v <= max_variation:
+                letters.append(k)
+        
+        return random.choice(letters), math.log(len(letters), 2)
 
     def add_information_amount(self, information_amount):
         self.information_amount+=information_amount 
 
     def update_program_num(self, r): #rの値に応じてprogram_numを増減
         self.program_num+=self.VARIATION_OF_PROGRAM_NUM[r]   
-    
-    def generate_token(self):
-        self.append_letter()
 
     def program_num_info(self): # program_num を出力
         return self.program_num
@@ -71,36 +48,16 @@ def generate():
     n=0
     a=1
     while(a>n):
-        sequence.generate_token()
+        sequence.append_letter()
         n+=1
         a=random.randint(0, 100)
         
-    sequence.change_max_variation_of_program_num()
     while(sequence.program_num_info()>1):
-        sequence.generate_token()
+        sequence.append_letter(-1)
     
     return sequence.sequence_info(), sequence.information_amount_info()
 
-def sorting():
-    while(True):
-        try:
-            sequence=[]
-            information_amount=0
-            sequence, information_amount=generate()
-            ps=calc.ProgramStack(sequence)
-            stack=ps.build()
-            if 'y' not in stack[0].find_free_variables():
-                if not stack[0].calc(1, 0)==stack[0].calc(10, 0):
-                    for num in range(1, 11):
-                        print(stack[0].calc(num, 0))
-                    break
-        except Exception:
-            continue
 
-    return sequence, information_amount
 
-for num in range(100):
-    g, h=sorting()
-    print(calc.ProgramStack.str2rpn(g))
 
 #A=0 B=1 C=2 D=+ E=- F=* G=div H=mod I=cond J=loop K=x L=y M=compr N=loop2

--- a/src/sequence_list_generator.py
+++ b/src/sequence_list_generator.py
@@ -43,21 +43,46 @@ class ProgramGenerator():
     def information_amount_info(self): # information_amount を出力
         return self.information_amount
 
+# 数列を生成
 def generate():
     sequence=ProgramGenerator()
     n=0
     a=1
+    max_num_of_loops=1000 # 下のwhile文の最大ループ回数
     while(a>n):
         sequence.append_letter()
         n+=1
-        a=random.randint(0, 100)
+        a=random.randint(1, max_num_of_loops)
         
+    # sequneceのprogram_numを1にする
     while(sequence.program_num_info()>1):
         sequence.append_letter(-1)
     
     return sequence.sequence_info(), sequence.information_amount_info()
 
+# 必要ない、価値が低い数列を除外
+def sorting():
+    while(True):
+        try:
+            sequence=[]
+            information_amount=0
+            sequence, information_amount=generate()
+            ps=sequence_generator.ProgramStack(sequence)
+            stack=ps.build()
+            # yが束縛されてないもの除外
+            if 'y' not in stack[0].find_free_variables():
+                # 定数数列を除外
+                if not (stack[0].calc(1, 0)==stack[0].calc(10, 0) and stack[0].calc(1, 0)==stack[0].calc(3, 0)):
+                    # y=xの数列を除外
+                    count=0
+                    for num in range(1, 11):
+                        if num == stack[0].calc(num, 0):
+                            count+=1
+                    if not count==10:
+                        break
 
+        except Exception:
+            continue
 
+    return sequence, information_amount
 
-#A=0 B=1 C=2 D=+ E=- F=* G=div H=mod I=cond J=loop K=x L=y M=compr N=loop2


### PR DESCRIPTION
数列の選別を行うsortingの関数をsequence_list_generator.pyへ追加。
また、sequence_generator.pyに起きていた、comprの無限ループ対策を追加。
実行時間の都合で現在compr_implの最大ループ数を10に設定しているので、要調整。
sequence_generator.pyのDivision,Modのmod0などの計算不能な数式に遭遇した時、エラーを返すように変更。